### PR TITLE
Fix トゥート to カツ on the preferences page

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -284,7 +284,7 @@ ja:
     visibilities:
       private: 非公開 - フォロワーだけに公開
       public: 公開 - 公開タイムラインに投稿する
-      unlisted: 未収載 - トゥートは公開するが、公開タイムラインには表示しない
+      unlisted: 未収載 - カツは公開するが、公開タイムラインには表示しない
   stream_entries:
     click_to_show: クリックして表示
     reblogged: ブーストされました


### PR DESCRIPTION
Note: I've preserved some "トゥート"s in config/locales/ja.yml,  because those strings are used only in admin pages.

BTW, english locales doesn't seem to Katsu!-nized. Do you want to keep those strings?