### PR TITLE
Use oops-rabbit.png in all error pages not only 500

### DIFF
--- a/app/views/layouts/error.html.haml
+++ b/app/views/layouts/error.html.haml
@@ -21,7 +21,6 @@
         margin: 20px auto;
         margin-top: 50px;
         max-width: 600px;
-        width: 100%;
         height: auto;
       }
 
@@ -31,6 +30,6 @@
       }
   %body
     .dialog
-      %img{:alt => "Mastodon", :src => "/oops.png"}/
+      %img{:alt => "Kirakiratter", :src => "/oops-rabbit.png"}/
       %div
         %h1= yield :content


### PR DESCRIPTION
`public/500.html` is already rebranded with oops-rabbit, but other errors use `app/views/layouts/error.html.haml`. So I've applied to the template too.